### PR TITLE
Actualización configuración bucket S3

### DIFF
--- a/HealthyIAC/iam.tf
+++ b/HealthyIAC/iam.tf
@@ -16,7 +16,14 @@ resource "aws_iam_role" "lambda_execution_role" {
   })
 }
 
+# Permisos básicos de ejecución de Lambda
 resource "aws_iam_role_policy_attachment" "lambda_logging" {
   role       = aws_iam_role.lambda_execution_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+# Permisos de acceso completo a S3 (subir, leer y eliminar archivos)
+resource "aws_iam_role_policy_attachment" "lambda_s3_access" {
+  role       = aws_iam_role.lambda_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
 }

--- a/HealthyIAC/s3.tf
+++ b/HealthyIAC/s3.tf
@@ -1,5 +1,41 @@
-# S3 Bucket
 resource "aws_s3_bucket" "healthy_app_files" {
-  bucket = var.bucket_name  # Usamos la variable definida en variables.tf
-  acl    = "private"        # Acceso privado
+  bucket = var.bucket_name
+}
+
+resource "aws_s3_bucket_website_configuration" "website_config" {
+  bucket = aws_s3_bucket.healthy_app_files.id
+
+  index_document {
+    suffix = "index.html"
+  }
+
+  error_document {
+    key = "index.html"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "public_access" {
+  bucket = aws_s3_bucket.healthy_app_files.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_policy" "public_read_policy" {
+  bucket = aws_s3_bucket.healthy_app_files.id
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid       = "PublicReadGetObject",
+        Effect    = "Allow",
+        Principal = "*",
+        Action    = "s3:GetObject",
+        Resource  = "${aws_s3_bucket.healthy_app_files.arn}/*"
+      }
+    ]
+  })
 }

--- a/HealthyIAC/terraform.tfstate
+++ b/HealthyIAC/terraform.tfstate
@@ -1,7 +1,7 @@
 {
   "version": 4,
   "terraform_version": "1.11.4",
-  "serial": 1227,
+  "serial": 1414,
   "lineage": "9d191706-c497-dec0-3bdb-d1f8a0fde47b",
   "outputs": {},
   "resources": [],

--- a/HealthyIAC/variables.tf
+++ b/HealthyIAC/variables.tf
@@ -5,7 +5,7 @@
 variable "bucket_name" {
   description = "Nombre del bucket S3"
   type        = string
-  default     = "healthy-app-files-1234567890"  # Aquí puedes cambiar el nombre por uno único
+  default     = "healthy-app-files-1234567890"  
 }
 
 # Cognito User Pool


### PR DESCRIPTION
Resumen de cambios:

Se configuró el bucket de S3 (healthy-app-files-1234567890) como sitio web estático.

Se habilitó el acceso público necesario para visualizar los archivos desplegados.

Se agregó la política de bucket adecuada (s3:GetObject) para archivos públicos.

Se sincronizaron los archivos del frontend Angular desde dist/ al bucket.

Se corrigió la estructura de carpetas para garantizar que index.html esté en la raíz del bucket.

Motivo del cambio:

Este cambio permite acceder públicamente a la aplicación Angular desde un navegador usando el endpoint del sitio web estático de S3, sin necesidad de CloudFront por ahora.